### PR TITLE
Add format option for memory and cpu

### DIFF
--- a/goblocks.json
+++ b/goblocks.json
@@ -25,6 +25,7 @@
 			"updateSignal": "37",
 			"command": "#Memory",
 			"suffix": "%",
+			"format": "%.2f",		
 			"timer": "2s"
 		},
 		{
@@ -32,6 +33,7 @@
 			"updateSignal": "38",
 			"command": "#Cpu",
 			"suffix": "%",
+			"format": "%.2f",		
 			"timer": "2s"
 		}
 	]

--- a/util/builtins.go
+++ b/util/builtins.go
@@ -30,7 +30,7 @@ func Memory(blockId int, send chan Change, rec chan bool, action map[string]inte
 	run := true
 	for run {
 		v, _ := mem.VirtualMemory()
-		send <- Change{blockId, fmt.Sprintf("%.2f", math.Round(v.UsedPercent*100)/100), true}
+		send <- Change{blockId, fmt.Sprintf(action["format"].(string), math.Round(v.UsedPercent*100)/100), true}
 		//Block untill other thread will ping you
 		run = <- rec
 	}
@@ -40,7 +40,7 @@ func Cpu(blockId int, send chan Change, rec chan bool, action map[string]interfa
 	run := true
 	for run {
 		val, _ := cpu.Percent(time.Second, false)
-		send <- Change{blockId, fmt.Sprintf("%.2f", math.Round(val[0]*100)/100), true}
+		send <- Change{blockId, fmt.Sprintf(action["format"].(string), math.Round(val[0]*100)/100), true}
 		//Block untill other thread will ping you
 		run = <- rec
 	}

--- a/util/builtins.go
+++ b/util/builtins.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
     "github.com/shirou/gopsutil/mem"
 	"github.com/shirou/gopsutil/cpu"
-	"math"
 )
 //blockId is automatically allocated
 //send channel is used to update blocks data
@@ -30,7 +29,7 @@ func Memory(blockId int, send chan Change, rec chan bool, action map[string]inte
 	run := true
 	for run {
 		v, _ := mem.VirtualMemory()
-		send <- Change{blockId, fmt.Sprintf(action["format"].(string), math.Round(v.UsedPercent*100)/100), true}
+		send <- Change{blockId, fmt.Sprintf(action["format"].(string), v.UsedPercent), true}
 		//Block untill other thread will ping you
 		run = <- rec
 	}
@@ -40,7 +39,7 @@ func Cpu(blockId int, send chan Change, rec chan bool, action map[string]interfa
 	run := true
 	for run {
 		val, _ := cpu.Percent(time.Second, false)
-		send <- Change{blockId, fmt.Sprintf(action["format"].(string), math.Round(val[0]*100)/100), true}
+		send <- Change{blockId, fmt.Sprintf(action["format"].(string), val[0]), true}
 		//Block untill other thread will ping you
 		run = <- rec
 	}


### PR DESCRIPTION
I wanted to able to format the memory and CPU percentages to keep them the same length.

For example, use `%6.2f` as a format to keep the length of the percentage always at 6.