### PR TITLE
Handle errors calling xsetroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Goblocks is a [dwm](https://dwm.suckless.org/) status bar program partially insp
 
 It is lightweight, fast, multithreaded, well(-ish) documented and easily customizable. It is also one of very few status bars done correctly. Most of them "naively"
 scan for changes every 1s or so, whereas goblocks only updates when there are updates to be done.
+
+## Dependencies
+Requires `xsetroot`
+
 ## Installation
 Pull this repo and run:
 ```

--- a/goblocks.go
+++ b/goblocks.go
@@ -11,9 +11,9 @@ import (
 )
 
 type configStruct struct {
-	Separator string
+	Separator          string
 	ConfigReloadSignal int //currently unused
-	Actions []map[string]interface{}
+	Actions            []map[string]interface{}
 }
 
 var blocks []string
@@ -21,8 +21,8 @@ var channels []chan bool
 var signalMap map[string]int = make(map[string]int)
 
 func main() {
-	config, err := readConfig(os.Getenv("HOME")+"/.config/goblocks.json")
-	if  err == nil {
+	config, err := readConfig(os.Getenv("HOME") + "/.config/goblocks.json")
+	if err == nil {
 		channels = make([]chan bool, len(config.Actions))
 		//recChannel is common for gothreads contributing to status bar
 		recChannel := make(chan util.Change)
@@ -35,7 +35,7 @@ func main() {
 				blocks = append(blocks, value.(string))
 			}
 			blocks = append(blocks, "action")
-			actionId := len(blocks)-1
+			actionId := len(blocks) - 1
 			if value, ok := action["suffix"]; ok {
 				blocks = append(blocks, value.(string))
 			}
@@ -56,7 +56,7 @@ func main() {
 		//start event loop
 		for {
 			//Block untill some gothread has an update
-			res := <- recChannel
+			res := <-recChannel
 			if res.Success {
 				blocks[res.BlockId] = res.Data
 			} else {
@@ -71,8 +71,9 @@ func main() {
 		fmt.Println(err)
 	}
 }
+
 //Read config and map it to configStruct
-func readConfig(path string) ( config configStruct, err error) {
+func readConfig(path string) (config configStruct, err error) {
 	var file *os.File
 	file, err = os.Open(path)
 	defer file.Close()

--- a/goblocks.go
+++ b/goblocks.go
@@ -63,7 +63,9 @@ func main() {
 				fmt.Println(res.Data)
 				blocks[res.BlockId] = "ERROR"
 			}
-			updateStatusBar()
+			if err = updateStatusBar(); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to update status bar: %s\n", err)
+			}
 		}
 	} else {
 		fmt.Println(err)
@@ -83,6 +85,7 @@ func readConfig(path string) ( config configStruct, err error) {
 	}
 	return config, err
 }
+
 //Goroutine that pings a channel according to received signal
 func handleSignals(rec chan os.Signal) {
 	for {
@@ -92,13 +95,14 @@ func handleSignals(rec chan os.Signal) {
 		}
 	}
 }
+
 //Craft status text out of blocks data
-func updateStatusBar() {
+func updateStatusBar() error {
 	var builder strings.Builder
 	for _, s := range blocks {
 		builder.WriteString(s)
 	}
 	//	fmt.Println(builder.String())
 	//	set dwm status text
-	exec.Command("xsetroot","-name",builder.String()).Run()
+	return exec.Command("xsetroot", "-name", builder.String()).Run()
 }


### PR DESCRIPTION
Outputs errors to stderr should there be an issue with calling xsetroot (like it not being installed):

`failed to update status bar: exec: "xsetroot": executable file not found in $PATH`