### PR TITLE
Handle errors calling xsetroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Goblocks is a [dwm](https://dwm.suckless.org/) status bar program partially insp
 
 It is lightweight, fast, multithreaded, well(-ish) documented and easily customizable. It is also one of very few status bars done correctly. Most of them "naively"
 scan for changes every 1s or so, whereas goblocks only updates when there are updates to be done.
+
+## Dependencies
+Requires `xsetroot`
+
 ## Installation
 Pull this repo and run:
 ```

--- a/goblocks.go
+++ b/goblocks.go
@@ -63,7 +63,9 @@ func main() {
 				fmt.Println(res.Data)
 				blocks[res.BlockId] = "ERROR"
 			}
-			updateStatusBar()
+			if err = updateStatusBar(); err != nil {
+				fmt.Fprintf(os.Stderr, "failed to update status bar: %s\n", err)
+			}
 		}
 	} else {
 		fmt.Println(err)
@@ -83,6 +85,7 @@ func readConfig(path string) ( config configStruct, err error) {
 	}
 	return config, err
 }
+
 //Goroutine that pings a channel according to received signal
 func handleSignals(rec chan os.Signal) {
 	for {
@@ -92,13 +95,14 @@ func handleSignals(rec chan os.Signal) {
 		}
 	}
 }
+
 //Craft status text out of blocks data
-func updateStatusBar() {
+func updateStatusBar() error {
 	var builder strings.Builder
 	for _, s := range blocks {
 		builder.WriteString(s)
 	}
 	//	fmt.Println(builder.String())
 	//	set dwm status text
-	exec.Command("xsetroot","-name",builder.String()).Run()
+	return exec.Command("xsetroot", "-name", builder.String()).Run()
 }


### PR DESCRIPTION
Outputs errors to stderr should there be an issue with calling xsetroot (like it not being installed):

`failed to update status bar: exec: "xsetroot": executable file not found in $PATH`